### PR TITLE
Take ownership of C string when creating an AvroStr

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -146,12 +146,14 @@ ffi_fn! {
     /// to make sure you are not freeing the memory or you need to set the
     /// owned flag to false.
     unsafe fn avro_str_from_c_str(s: *const c_char) -> Result<AvroStr> {
-        let s = CStr::from_ptr(s).to_str()?;
-        Ok(AvroStr {
+        let s = CStr::from_ptr(s).to_str()?.to_owned();  // can we not own it?
+        let rv = Ok(AvroStr {
             data: s.as_ptr() as *mut _,
             len: s.len(),
             owned: true,
-        })
+        });
+        mem::forget(s);
+        rv
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -13,7 +13,7 @@ pub struct AvroValue;
 #[no_mangle]
 pub unsafe extern "C" fn avro_value_free(v: *mut AvroValue) {
     if !v.is_null() {
-        Box::from_raw(v);
+        Box::from_raw(v as *mut Value);
     }
 }
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -41,7 +41,8 @@ ffi_fn! {
     unsafe fn avro_writer_append2(writer: *mut AvroWriter, value: *mut AvroValue) -> Result<usize> {
         let writer = &mut *(writer as *mut Writer<Vec<u8>>);
         let value = *(Box::from_raw(value as *mut Value));
-        Ok(writer.append(value)?)
+        let value = value.resolve(writer.schema())?;  // Python's type system is not as strict as Rust's. This `.resolve` allows us to be more laxist
+        Ok(writer.append_value_ref(&value)?)
     }
 }
 


### PR DESCRIPTION
When coming from Python, this would prevent GC from eating it